### PR TITLE
(modules) fix compile error for treesitter-norg

### DIFF
--- a/fnl/modules/tools/tree-sitter/config.fnl
+++ b/fnl/modules/tools/tree-sitter/config.fnl
@@ -70,7 +70,8 @@
                    (set parser-config.norg
                         {:install_info {:url "https://github.com/nvim-neorg/tree-sitter-norg"
                                         :files [:src/parser.c :src/scanner.cc]
-                                        :branch :dev}})
+                                        :branch :dev
+                                        :use_makefile true}})
                    (set parser-config.norg_meta
                         {:install_info {:url "https://github.com/nvim-neorg/tree-sitter-norg-meta"
                                         :files [:src/parser.c]


### PR DESCRIPTION
### Test Environment
- Model: Macbook Pro 16" (2019, Intel)
- OS: MacOS Ventura

### Description

`nyoom sync` command fails because of compile error on `nvim-treesitter-norg`.

With default compile options, c++ standard is not specified, so compiling `scanner.cc` is failed by c++11 syntax.

This can be fixed by using makefile that specifies c++ standard option correctly.