### PR TITLE
Vimtex hydra

### DIFF
--- a/fnl/modules/ui/hydra/config.fnl
+++ b/fnl/modules/ui/hydra/config.fnl
@@ -318,7 +318,7 @@
                                       :hint {:position :middle :border :solid}
                                       :buffer true}
                              :mode :n
-                             :body :<Leader>r
+                             :body :<Leader>m
                              :heads [[:r
                                       (fn []
                                         (vim.cmd.RustRunnables))

--- a/fnl/modules/ui/hydra/config.fnl
+++ b/fnl/modules/ui/hydra/config.fnl
@@ -318,7 +318,7 @@
                                       :hint {:position :middle :border :solid}
                                       :buffer true}
                              :mode :n
-                             :body :<Leader>m
+                             :body :<Leader>r
                              :heads [[:r
                                       (fn []
                                         (vim.cmd.RustRunnables))

--- a/fnl/modules/ui/hydra/config.fnl
+++ b/fnl/modules/ui/hydra/config.fnl
@@ -370,13 +370,14 @@
                  (do
                    (fn latex-hydra []
                      (local vimtex-hint "
-    ^VimTex                    
-    ^                          
-    _c_: Continuous Compile    
-    _s_: Snapshot Compile      
-    _e_: Clean Up Extra Files  
-    ^                          
-    ^^^^^^                   _<Esc>_^^^
+    ^                     VimTex                      
+    ^                                                 
+    _ll_: Continuous Compile    _ss_: Snapshot Compile
+    _lC_: Clean Up Files        _lt_: Table of Content
+    _cw_: Count Words           _cl_: Count Letters   
+    _le_: Errors                _lq_: Log             
+    ^                                                 
+    ^_h_: Default Maps                      _<Esc>_^^^
        ")
                      (Hydra {:name :+latex
                              :hint vimtex-hint
@@ -385,19 +386,43 @@
                                       :hint {:border :solid :position :middle}
                                       :buffer true}
                              :mode [:n :x]
-                             :body :<leader>m
-                             :heads [[:c
+                             :body :<leader>t
+                             :heads [[:ll
                                       (fn []
                                         (vim.cmd :VimtexCompile))
                                       {:exit true}]
-                                     [:s
+                                     [:ss
                                       (fn []
                                         (vim.cmd :VimtexCompileSS))
                                       {:exit true}]
-                                     [:e
+                                     [:lC
                                       (fn []
                                         (vim.cmd :VimtexClean!))
                                       {:exit true}]
+                                     [:cw
+                                       (fn []
+                                          (vim.cmd :VimtexCountWords))
+                                       {:exit true}]
+                                     [:cl
+                                       (fn []
+                                         (vim.cmd :VimtexCountLetters))
+                                       {:exit true}]
+                                     [:le
+                                       (fn []
+                                         (vim.cmd :VimtexErrors))
+                                       {:exit true}]
+                                     [:lt
+                                       (fn []
+                                         (vim.cmd :VimtexTocToggle))
+                                       {:exit true}]
+                                     [:lq
+                                       (fn []
+                                         (vim.cmd :VimtexLog))
+                                       {:exit true}]
+                                     [:h
+                                       (fn []
+                                         (vim.cmd :h vimtex-mefault-mappings))
+                                       {:exit true}]
                                      [:<Esc> nil {:exit true :nowait true}]]}))
                    (augroup! localleader-hydras
                              (autocmd! FileType tex `(latex-hydra)))))

--- a/fnl/modules/ui/hydra/init.fnl
+++ b/fnl/modules/ui/hydra/init.fnl
@@ -4,8 +4,8 @@
               {:nyoom-module ui.hydra
                :module :hydra
                :keys [:<leader>g
-                      :<leader>o
+                      :<leader>v
                       :<leader>f
-                      :<leader>z
+                      :<leader>d
                       :<leader>m
-                      :<leader>d]})
+                      :<leader>t]})

--- a/fnl/modules/ui/hydra/init.fnl
+++ b/fnl/modules/ui/hydra/init.fnl
@@ -7,5 +7,5 @@
                       :<leader>v
                       :<leader>f
                       :<leader>d
-                      :<leader>r
+                      :<leader>m
                       :<leader>t]})

--- a/fnl/modules/ui/hydra/init.fnl
+++ b/fnl/modules/ui/hydra/init.fnl
@@ -7,5 +7,5 @@
                       :<leader>v
                       :<leader>f
                       :<leader>d
-                      :<leader>m
+                      :<leader>r
                       :<leader>t]})


### PR DESCRIPTION
This PR does two things:

1. Fixes a conflict with nyoom's default `<localleader>` mapping and the Rust and VimTex hydras.
2. Revamps the VimTex hydra.

1. Localleader Conflicts

Nyoom by default maps `<leader>` to `<SPC>` and `<localleader>` to `<SPC>m`. The Rust and VimTex hydra bodiess are activated on `<leader>m`, causing a conflict with `<localleader>`. My PR changes the Rust hydra body to `<leader>r` and VimTex hydra Body to `<leader>t`.

2. VimTex Hydra Revamp

VimTex by [default](https://github.com/lervag/vimtex/blob/master/doc/vimtex.txt) has a number of useful mappings onto `<localleader>` and other keys, including `:VimtexCompile`, `:VimtexClean!`, `:VimtexErrors`, and others.

While for some of these the default mapping is much faster than going through a hydra, the hydra is visually much neater and more friendly for someone who isn't familiar with VimTex in particular. There are also a couple very handy commands, such as `:VimtexCountWords/Letters`, which are not included in the defaults.

My PR firstly changes the heads for the commands with existing VT defaults to be in line with them. Then it adds the additional commands that are useful. And finally it adds a direct call to `:h vimtex-default-mappings` for a list of all the default mappings.