### PR TITLE
Fix clangd lspconfig

### DIFF
--- a/fnl/modules/tools/lsp/config.fnl
+++ b/fnl/modules/tools/lsp/config.fnl
@@ -78,6 +78,8 @@
 
 ;; conditional servers
 
+(nyoom-module-p! cc (tset lsp-servers :clangd {:cmd [:clangd]}))
+
 (nyoom-module-p! csharp (tset lsp-servers :omnisharp {:cmd [:omnisharp]}))
 
 (nyoom-module-p! clojure (tset lsp-servers :clojure_lsp {}))

--- a/fnl/modules/tools/lsp/config.fnl
+++ b/fnl/modules/tools/lsp/config.fnl
@@ -95,7 +95,7 @@
 (nyoom-module-p! latex (tset lsp-servers :texlab {}))
 
 (nyoom-module-p! lua
-                 (tset lsp-servers :sumneko_lua
+                 (tset lsp-servers :lua_ls
                        {:settings {:Lua {:diagnostics {:globals [:vim]}
                                          :workspace {:library (vim.api.nvim_list_runtime_paths)
                                                      :maxPreload 100000}}}}))


### PR DESCRIPTION
This should fix the error: "config for clangd language server not found"

Not sure if when done like that clangd will use  clangd_extensions.nvim, but that was the only way in which i could get it to work.

Maybe there's a better way?