### PR TITLE
Change :help to :vimdoc

### DIFF
--- a/fnl/modules/tools/tree-sitter/config.fnl
+++ b/fnl/modules/tools/tree-sitter/config.fnl
@@ -8,7 +8,7 @@
                    (let [leap-ast (autoload :leap-ast)]
                      (map! [nxo] :gs `(leap-ast.leap) {:desc "Leap AST"}))))
 
-(local treesitter-filetypes [:help :fennel :vim :regex :query])
+(local treesitter-filetypes [:vimdoc :fennel :vim :regex :query])
 
 ;; conditionally install parsers
 


### PR DESCRIPTION
Brought up in #128 syncing may produce an error saying `parser not available for language "help"` so I changed it to `vimdoc` so treesitter can update properly and no errors show when syncing