### PR TITLE
fix: install/sync with NVIM_APPNAME

### DIFF
--- a/bin/nyoom
+++ b/bin/nyoom
@@ -20,7 +20,7 @@ if [[ "$NYOOM_CURRENT_DIR_REAL" != "$CONFIG_PATH" ]]; then
 		NVIM_APPNAME=$NYOOM_BASENAME
 	else
 		echo "";
-		echo "Please clone Nyoom to ~/.config/nyoom or run this command as 'NVIM_APPNAME=${NYOOM_BASENAME} bin/nyoom ${1:-}'"
+		echo "Please clone Nyoom to ~/.config/nvim or run this command as 'NVIM_APPNAME=${NYOOM_BASENAME} bin/nyoom ${1:-}'"
 		exit;
 	fi
 

--- a/bin/nyoom
+++ b/bin/nyoom
@@ -3,9 +3,10 @@
 set -o errexit -o pipefail -o nounset
 
 # people like xdg
-CONFIG_PATH="${XDG_CONFIG_HOME:-${HOME}/.config}/${NVIM_APPNAME:-nvim}"
-CACHE_PATH="${XDG_CACHE_HOME:-${HOME}/.cache}/${NVIM_APPNAME:-nvim}"
-DATA_PATH="${XDG_DATA_HOME:-${HOME}/.local/share}/${NVIM_APPNAME:-nvim}"
+NVIM_APPNAME="${NVIM_APPNAME:-nvim}"
+CONFIG_PATH="${XDG_CONFIG_HOME:-${HOME}/.config}/${NVIM_APPNAME}"
+CACHE_PATH="${XDG_CACHE_HOME:-${HOME}/.cache}/${NVIM_APPNAME}"
+DATA_PATH="${XDG_DATA_HOME:-${HOME}/.local/share}/${NVIM_APPNAME}"
 NYOOM_CONFIG="${XDG_DATA_HOME:-${HOME}/.config}/nyoom"
 
 mkdir -p "$CONFIG_PATH" "$CACHE_PATH" "$DATA_PATH" "$NYOOM_CONFIG"
@@ -77,7 +78,7 @@ sync)
 	rm -f "${CONFIG_PATH}/lua/packer_compiled.lua" || true
 	# set ulimit to fix packer.sync hanging with --headless: https://github.com/wbthomason/packer.nvim/issues/751
 	ulimit -S -n 4096
-	NYOOM_CLI=true nvim --headless -c 'autocmd User PackerComplete quitall' -c 'lua require("packer").sync()'
+	NYOOM_CLI=true NVIM_APPNAME=$NVIM_APPNAME nvim --headless -c 'autocmd User PackerComplete quitall' -c 'lua require("packer").sync()'
 	echo
 	if [ -d "${DATA_PATH}/site/pack/packer/opt/nvim-treesitter/" ]; then
 		echo

--- a/bin/nyoom
+++ b/bin/nyoom
@@ -9,6 +9,23 @@ CACHE_PATH="${XDG_CACHE_HOME:-${HOME}/.cache}/${NVIM_APPNAME}"
 DATA_PATH="${XDG_DATA_HOME:-${HOME}/.local/share}/${NVIM_APPNAME}"
 NYOOM_CONFIG="${XDG_DATA_HOME:-${HOME}/.config}/nyoom"
 
+NYOOM_CURRENT_DIR_REAL=$(realpath "$(pwd)")
+NYOOM_BASENAME=$(basename "$(pwd)")
+
+if [[ "$NYOOM_CURRENT_DIR_REAL" != "$CONFIG_PATH" ]]; then
+	echo "The directory you're running bin/nyoom ${1:-} in is not the expected location.";
+	echo
+	read -p "Set NVIM_APPNAME=${NYOOM_BASENAME} before continuing?  " -n 1 -r;
+	if [[ $REPLY =~ ^[Yy]$ ]]; then
+		NVIM_APPNAME=$NYOOM_BASENAME
+	else
+		echo "";
+		echo "Please clone Nyoom to ~/.config/nyoom or run this command as 'NVIM_APPNAME=${NYOOM_BASENAME} bin/nyoom ${1:-}'"
+		exit;
+	fi
+
+fi
+
 mkdir -p "$CONFIG_PATH" "$CACHE_PATH" "$DATA_PATH" "$NYOOM_CONFIG"
 
 # silently enter ${CONFIG_PATH} when updating

--- a/bin/nyoom
+++ b/bin/nyoom
@@ -10,7 +10,7 @@ DATA_PATH="${XDG_DATA_HOME:-${HOME}/.local/share}/${NVIM_APPNAME}"
 NYOOM_CONFIG="${XDG_DATA_HOME:-${HOME}/.config}/nyoom"
 
 NYOOM_CURRENT_DIR_REAL=$(realpath "$(pwd)")
-NYOOM_BASENAME=$(basename "$(pwd)")
+NYOOM_BASENAME=$(basename "$NYOOM_CURRENT_DIR_REAL")
 
 if [[ "$NYOOM_CURRENT_DIR_REAL" != "$CONFIG_PATH" ]]; then
 	echo "The directory you're running bin/nyoom ${1:-} in is not the expected location.";


### PR DESCRIPTION
This uses NVIM_APPNAME during install/sync if needed. It also checks to make sure the cwd is the nvim appname and if not asks to set it to the basename of the cwd.

<img width="1066" alt="Screenshot 2023-11-04 at 9 30 46 AM" src="https://github.com/nyoom-engineering/nyoom.nvim/assets/14190743/e4faf691-c6e8-4f8d-a594-7f84bd32a62d">

<img width="991" alt="Screenshot 2023-11-04 at 9 30 53 AM" src="https://github.com/nyoom-engineering/nyoom.nvim/assets/14190743/e01c07b9-5de8-46c7-9751-9acee1b77166">

Related to https://github.com/nyoom-engineering/nyoom.nvim/discussions/124